### PR TITLE
Update runtime version from 49 to 50 and more

### DIFF
--- a/io.github.Predidit.Kazumi.metainfo.xml
+++ b/io.github.Predidit.Kazumi.metainfo.xml
@@ -10,8 +10,36 @@
   </developer>
   <metadata_license>MIT</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
+  <url type="homepage">https://github.com/Predidit/Kazumi</url>
+  <url type="bugtracker">https://github.com/Predidit/Kazumi/issues</url>
+  <url type="vcs-browser">https://github.com/Predidit/Kazumi</url>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">intense</content_attribute>
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-realistic">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="violence-sexual">intense</content_attribute>
+    <content_attribute id="violence-desecration">intense</content_attribute>
+    <content_attribute id="violence-slavery">intense</content_attribute>
+    <content_attribute id="drugs-alcohol">moderate</content_attribute>
+    <content_attribute id="drugs-narcotics">moderate</content_attribute>
+    <content_attribute id="drugs-tobacco">moderate</content_attribute>
+    <content_attribute id="sex-nudity">intense</content_attribute>
+    <content_attribute id="sex-themes">intense</content_attribute>
+    <content_attribute id="language-profanity">intense</content_attribute>
+    <content_attribute id="language-humor">intense</content_attribute>
+    <content_attribute id="language-discrimination">intense</content_attribute>
+    <content_attribute id="money-advertising">moderate</content_attribute>
+  </content_rating>
+  <launchable type="desktop-id">io.github.Predidit.Kazumi.desktop</launchable>
+  <provides>
+    <binary>kazumi</binary>
+  </provides>
   <description>
-    <p>Kazumi is an anime streaming application that allows you to create collections and view them according to customized rules. This app is designed to help you stream content from different platforms, featuring online comments with its built-in 'live danmaku' feature for an enhanced viewing experience. Please note that all content within the app is exclusively available in Chinese, providing a smooth, customizable way of enjoying your favorite anime.</p>
+    <p>**NOTE: All content within the app is exclusively available in Chinese.**</p>
+    <p>Kazumi is an anime streaming application that allows you to create collections and view them according to customized rules.
+      This app is designed to help you stream content from different platforms, featuring online comments with its built-in
+      'live danmaku' feature for an enhanced viewing experience, providing a smooth, customizable way of enjoying your favorite anime.</p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -28,314 +56,17 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="2.0.7" date="2026-04-09">
-      <description></description>
-    </release>
-    <release version="2.0.6" date="2026-03-26">
-      <description/>
-    </release>
-    <release version="2.0.5" date="2026-03-07">
-      <description/>
-    </release>
-    <release version="2.0.4" date="2026-03-03">
-      <description/>
-    </release>
-    <release version="2.0.3" date="2026-02-20">
-      <description/>
-    </release>
-    <release version="2.0.2" date="2026-02-12">
-      <description/>
-    </release>
-    <release version="2.0.1" date="2026-02-08">
-      <description/>
-    </release>
-    <release version="2.0.0" date="2026-02-06">
-      <description/>
-    </release>
-    <release version="1.9.6" date="2026-01-30">
-      <description/>
-    </release>
-    <release version="1.9.5" date="2026-01-28">
-      <description/>
-    </release>
-    <release version="1.9.4" date="2026-01-09">
-      <description/>
-    </release>
-    <release version="1.9.3" date="2025-12-11">
-      <description/>
-    </release>
-    <release version="1.9.2" date="2025-12-05">
-      <description/>
-    </release>
-    <release version="1.9.1" date="2025-11-27">
-      <description/>
-    </release>
-    <release version="1.9.0" date="2025-11-19">
-      <description/>
-    </release>
-    <release version="1.8.9" date="2025-11-19">
-      <description/>
-    </release>
-    <release version="1.8.8" date="2025-11-15">
-      <description/>
-    </release>
-    <release version="1.8.7" date="2025-10-29">
-      <description/>
-    </release>
-    <release version="1.8.6" date="2025-10-22">
-      <description/>
-    </release>
-    <release version="1.8.5" date="2025-10-21">
-      <description/>
-    </release>
-    <release version="1.8.4" date="2025-10-14">
-      <description/>
-    </release>
-    <release version="1.8.3" date="2025-10-14">
-      <description/>
-    </release>
-    <release version="1.8.2" date="2025-09-25">
-      <description>
-        <ul>
-          <li>新增新番时间表排序功能 (@Predidit)</li>
-          <li>改进 Linux 平台视频解析器 (#1055) (@Predidit)</li>
-          <li>修复 Windows 平台退出全屏可能UI冻结的问题 (#1178) (@Predidit)</li>
-          <li>修复自动更新功能可能的URL解析错误 (@UzawaReisaQwQ)</li>
-          <li>修复播放器调试日志无法响应式更新的问题 (@Predidit)</li>
-          <li>修复可能的UI布局问题 (#1323) (@Predidit)</li>
-          <li>现在番剧规则查询可以被优雅地取消 (@Predidit)</li>
-          <li>轮换示例规则 (@Predidit)</li>
-        </ul>
-      </description>
-    </release>
-    <release version="1.8.1" date="2025-09-19">
-      <description/>
-    </release>
-    <release version="1.8.0" date="2025-09-18">
-      <description/>
-    </release>
-    <release version="1.7.9" date="2025-09-10">
-      <description/>
-    </release>
-    <release version="1.7.8" date="2025-09-04">
-      <description/>
-    </release>
-    <release version="1.7.7" date="2025-08-17">
-      <description/>
-    </release>
-    <release version="1.7.6" date="2025-08-11">
-      <description/>
-    </release>
-    <release version="1.7.5" date="2025-07-27">
-      <description/>
-    </release>
-    <release version="1.7.4" date="2025-07-01">
-      <description/>
-    </release>
-    <release version="1.7.3" date="2025-06-07">
-      <description/>
-    </release>
-    <release version="1.7.2" date="2025-05-21">
-      <description/>
-    </release>
-    <release version="1.7.1" date="2025-05-14">
-      <description/>
-    </release>
-    <release version="1.7.0" date="2025-05-08">
-      <description/>
-    </release>
-    <release version="1.6.9" date="2025-04-30">
-      <description/>
-    </release>
-    <release version="1.6.8" date="2025-04-24">
-      <description/>
-    </release>
-    <release version="1.6.7" date="2025-04-19">
-      <description/>
-    </release>
-    <release version="1.6.6" date="2025-04-13">
-      <description/>
-    </release>
-    <release version="1.6.5" date="2025-04-07">
-      <description/>
-    </release>
-    <release version="1.6.4" date="2025-04-02">
-      <description/>
-    </release>
-    <release version="1.6.3" date="2025-03-27">
-      <description/>
-    </release>
-    <release version="1.6.2" date="2025-03-20">
-      <description/>
-    </release>
-    <release version="1.6.1" date="2025-03-09">
-      <description/>
-    </release>
-    <release version="1.6.0" date="2025-03-03">
-      <description/>
-    </release>
-    <release version="1.5.9" date="2025-02-25">
-      <description/>
-    </release>
-    <release version="1.5.8" date="2025-02-19">
-      <description/>
-    </release>
-    <release version="1.5.7" date="2025-02-13">
-      <description/>
-    </release>
-    <release version="1.5.6" date="2025-02-08">
-      <description/>
-    </release>
-    <release version="1.5.5" date="2025-02-02">
-      <description/>
-    </release>
-    <release version="1.5.4" date="2025-01-26">
-      <description/>
-    </release>
-    <release version="1.5.3" date="2025-01-21">
-      <description/>
-    </release>
-    <release version="1.5.2" date="2025-01-16">
-      <description/>
-    </release>
-    <release version="1.5.1" date="2025-01-11">
-      <description/>
-    </release>
-    <release version="1.5.0" date="2025-01-04">
-      <description/>
-    </release>
-    <release version="1.4.9" date="2025-01-01">
-      <description/>
-    </release>
-    <release version="1.4.8" date="2024-12-25">
-      <description/>
-    </release>
-    <release version="1.4.7" date="2024-12-19">
-      <description/>
-    </release>
-    <release version="1.4.6" date="2024-12-13">
-      <description/>
-    </release>
-    <release version="1.4.5" date="2024-12-06">
-      <description/>
-    </release>
-    <release version="1.4.4" date="2024-11-23">
-      <description/>
-    </release>
-    <release version="1.4.3" date="2024-11-16">
-      <description/>
-    </release>
-    <release version="1.4.2" date="2024-11-09">
-      <description/>
-    </release>
-    <release version="1.4.1" date="2024-11-02" type="stable">
-      <description>
-        <ul>
-          <li>Redesigned desktop player animation logic (@ErBWs)</li>
-          <li>Fixed occasional video aspect ratio errors on iOS (#226) (@ErBWs)</li>
-          <li>Fixed an issue where player shortcuts would not work in certain situations (@Predidit)</li>
-          <li>Fixed an issue where autoplaying the next episode would switch to playlist 1 (#359) (@Predidit)</li>
-          <li>Now, when continuing to watch long-form animations, the episode list will automatically scroll to the current episode position (@ErBWs)</li>
-          <li>Minor UI optimizations (@ErBWs)</li>
-        </ul>
-      </description>
-    </release>
-    <release version="1.4.0" date="2024-10-25" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.9" date="2024-10-18" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.8" date="2024-10-18" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.7" date="2024-10-17" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.6" date="2024-10-10" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.5" date="2024-10-04" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.4" date="2024-09-28" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.3" date="2024-09-22" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.2" date="2024-09-16" type="stable">
-      <description/>
-    </release>
-    <release version="1.3.1" date="2024-09-10" type="stable">
-      <description>
-        <ul>
-          <li>Redesigned anime series detail page</li>
-          <li>Improved video parser</li>
-          <li>Fixed danmaku area settings not taking effect (#211)</li>
-          <li>Fixed danmaku not resuming after changing settings while paused (#211)</li>
-          <li>Resolved issue with video playing muted on iOS in silent mode (#214)</li>
-          <li>Corrected watch history errors in specific scenarios</li>
-          <li>Optimized Windows application icon (@first-storm)</li>
-          <li>Rotated sample rules</li>
-        </ul>
-      </description>
-    </release>
-    <release version="1.3.0" date="2024-09-03" type="stable">
-      <description>
-        <ul>
-          <li>Improve the video decoder.</li>
-          <li>Now support video sources retrieved via POST requests.</li>
-          <li>Now use memory for video caching as much as possible to enhance viewing experience.</li>
-          <li>Add low-memory mode, which falls back to a low-memory player mode when enabled.</li>
-          <li>Optimize the loading process for live comments (danmaku).</li>
-          <li>Fix the background flickering issue on the anime detail page.</li>
-          <li>Fix the color block issue during fullscreen playback on iOS.</li>
-          <li>Replace example rules.</li>
-        </ul>
-      </description>
-    </release>
-    <release version="1.2.9" date="2024-08-28" type="stable"/>
-    <release version="1.2.8" date="2024-08-23" type="stable"/>
-    <release version="1.2.7" date="2024-08-19" type="stable"/>
-    <release version="1.2.6" date="2024-08-11" type="stable"/>
-    <release version="1.2.5" date="2024-08-01" type="stable"/>
-    <release version="1.2.4" date="2024-07-28" type="stable"/>
-    <release version="1.2.3" date="2024-07-24" type="stable"/>
-    <release version="1.2.2" date="2024-07-21" type="stable"/>
-    <release version="1.2.1" date="2024-07-16" type="stable"/>
-    <release version="1.2.0" date="2024-07-15" type="stable"/>
-    <release version="1.1.9" date="2024-07-12" type="stable"/>
-    <release version="1.1.8" date="2024-07-08" type="stable"/>
-    <release version="1.1.7" date="2024-07-05" type="stable"/>
-    <release version="1.1.6" date="2024-07-02" type="stable"/>
-    <release version="1.1.5" date="2024-06-29" type="stable"/>
-    <release version="1.1.4" date="2024-06-27" type="stable"/>
-    <release version="1.1.3" date="2024-06-24" type="stable"/>
-    <release version="1.1.2" date="2024-06-20" type="stable"/>
-    <release version="1.1.1" date="2024-06-15" type="stable"/>
-    <release version="1.1.0" date="2024-06-14" type="stable"/>
-    <release version="1.0.9" date="2024-06-12" type="stable"/>
-    <release version="1.0.8" date="2024-06-05" type="stable"/>
-    <release version="1.0.7" date="2024-05-28" type="stable"/>
-    <release version="1.0.6" date="2024-05-27" type="stable"/>
-    <release version="1.0.5" date="2024-05-24" type="stable"/>
-    <release version="1.0.4" date="2024-05-22" type="stable"/>
-    <release version="1.0.3" date="2024-05-20" type="stable"/>
-    <release version="1.0.2" date="2024-05-19" type="stable"/>
-    <release version="1.0.1" date="2024-05-18" type="stable"/>
+    <release version="2.0.7" date="2026-04-09"/>
+    <release version="2.0.6" date="2026-03-26"/>
+    <release version="2.0.5" date="2026-03-07"/>
+    <release version="2.0.4" date="2026-03-03"/>
+    <release version="2.0.3" date="2026-02-20"/>
+    <release version="2.0.2" date="2026-02-12"/>
+    <release version="2.0.1" date="2026-02-08"/>
+    <release version="2.0.0" date="2026-02-06"/>
+    <release version="1.9.6" date="2026-01-30"/>
+    <release version="1.9.5" date="2026-01-28"/>
+    <release version="1.9.4" date="2026-01-09"/>
     <release version="1.0.0" date="2024-05-17" type="stable"/>
   </releases>
-  <url type="homepage">https://github.com/Predidit/Kazumi</url>
-  <url type="bugtracker">https://github.com/Predidit/Kazumi/issues</url>
-  <categories>
-    <category>AudioVideo</category>
-    <category>Audio</category>
-    <category>Video</category>
-  </categories>
-  <content_rating type="oars-1.1"/>
-  <launchable type="desktop-id">io.github.Predidit.Kazumi.desktop</launchable>
-  <provides>
-    <binary>kazumi</binary>
-  </provides>
 </component>

--- a/io.github.Predidit.Kazumi.yaml
+++ b/io.github.Predidit.Kazumi.yaml
@@ -1,7 +1,7 @@
 id: io.github.Predidit.Kazumi
 # This app needs libwebkit2gtk-4.1 to work properly.
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: kazumi
 finish-args:
@@ -16,16 +16,6 @@ finish-args:
   - --own-name=org.mpris.MediaPlayer2.io.github.predidit.kazumi.*
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.ScreenSaver
-cleanup:
-  - '*.a'
-  - '*.la'
-  - /include
-  - /lib/cmake
-  - /lib/pkgconfig
-  - /man
-  - /share/man
-  - /share/gtk-doc
-
 modules:
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
   - name: kazumi


### PR DESCRIPTION
- Update the runtime version to 50
- Update shared-modules
- Drop ineffective cleanup commands
- Update metadata to reflect the age
- Fix appdata paper cuts
- Drop extensive and mostly empty release history